### PR TITLE
fix kernel_vpp plugin some bugs

### DIFF
--- a/src/libcharon/plugins/kernel_vpp/README.md
+++ b/src/libcharon/plugins/kernel_vpp/README.md
@@ -9,7 +9,7 @@ GCM is also supported and VPP must run with DPDK with crypto device or device th
 ## How to build strongswan for VPP ##
 Install vpp-lib and vpp-dev packages. The plugins are disabled by default and can be enabled by adding:
 
-    --enable-socket-vpp --enable-kernel-vpp --enable-libipsec
+    --enable-socket-vpp --enable-kernel-vpp
 
 to the ./configure options.
 

--- a/src/libcharon/plugins/kernel_vpp/kernel_vpp_ipsec.c
+++ b/src/libcharon/plugins/kernel_vpp/kernel_vpp_ipsec.c
@@ -366,8 +366,8 @@ static uint32_t get_sw_if_index(char *interface)
     mp->_vl_msg_id = htons(VL_API_SW_INTERFACE_DUMP);
     mp->name_filter_valid = TRUE;
     mp->name_filter.length = htonl (name_filter_len);
-    strncpy((char *) mp->name_filter.buf, interface, name_filter_len);
-
+   // strncpy((char *) mp->name_filter.buf, interface, name_filter_len);
+    clib_memcpy_fast (mp->name_filter.buf, interface, name_filter_len);
     if (vac->send(vac, (char *)mp, msg_len, &out, &out_len))
     {
         goto error;
@@ -895,7 +895,8 @@ METHOD(kernel_ipsec_t, add_sa, status_t,
     mp->_vl_msg_id = htons(VL_API_IPSEC_SAD_ENTRY_ADD_DEL);
     mp->is_add = 1;
     mp->entry.sad_id = htonl(sad_id);
-    mp->entry.spi = htonl(id->spi);
+    //mp->entry.spi = htonl(id->spi);
+    mp->entry.spi = id->spi;
     mp->entry.protocol = id->proto == IPPROTO_ESP?htonl(IPSEC_API_PROTO_ESP):htonl(IPSEC_API_PROTO_AH);
 #if 0    
     mp->entry.dst_port = ntohs(id->dst->get_port(id->dst));

--- a/src/libcharon/plugins/kernel_vpp/kernel_vpp_shared.c
+++ b/src/libcharon/plugins/kernel_vpp/kernel_vpp_shared.c
@@ -548,7 +548,7 @@ METHOD(vac_t, register_event, status_t, private_vac_t *this, char *in,
     if (rmp->retval)
         return FAILED;
     free(out);
-	free(in);
+	vac_free(in);
     this->events_lock->lock(this->events_lock);
     INIT(event,
             .cb = cb,


### PR DESCRIPTION
1、fix strongswan crash when vpp configure ip address。
2、fix strongswan spi  Byte order error。
3、fix kernel_vpp README.md error，Ike negotiation is carried out through VPP channel don‘t need “enable-libipsec”，this plugin is enable because the plugin priority，the udp port will 4500 Even if there is no NAT on the opposite side。